### PR TITLE
Adding fortio log tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOTEST_FLAGS=-cpu=1,2,4 -benchmem -benchtime=5s
 
-TEXT_PKGS=Gokit Logrus Log15 Gologging Seelog Zerolog
+TEXT_PKGS=Gokit Logrus Log15 Gologging Seelog Zerolog Fortiolog
 JSON_PKGS=Gokit Logrus Log15 Zerolog
 
 TEXT_PKG_TARGETS=$(addprefix test-text-,$(TEXT_PKGS))
@@ -17,6 +17,7 @@ deps:
 	go get -u github.com/cihub/seelog
 	go get -u github.com/go-kit/kit/log
 	go get -u github.com/rs/zerolog
+	go get -u fortio.org/fortio
 
 test: test-text test-json
 

--- a/fortiolog_test.go
+++ b/fortiolog_test.go
@@ -1,0 +1,41 @@
+package bench
+
+import (
+	"testing"
+
+	log "fortio.org/fortio/log"
+)
+
+func BenchmarkFortiologTextNegative(b *testing.B) {
+	stream := &blackholeStream{}
+	log.SetLogLevel(log.Error)
+	log.SetOutput(stream)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			log.Infof("The quick brown fox jumps over the lazy dog")
+		}
+	})
+
+	if stream.WriteCount() != uint64(0) {
+		b.Fatalf("Log write count")
+	}
+}
+
+func BenchmarkFortiologTextPositive(b *testing.B) {
+	stream := &blackholeStream{}
+	log.SetLogLevel(log.Info)
+	log.SetOutput(stream)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			log.Infof("The quick brown fox jumps over the lazy dog")
+		}
+	})
+
+	if stream.WriteCount() != uint64(b.N) {
+		b.Fatalf("Log write count")
+	}
+}


### PR DESCRIPTION
Copied/adapted from Seelog tests

on my mac:
```
$ make test-text-Fortiolog
go test -cpu=1,2,4 -benchmem -benchtime=5s -bench "Fortiolog.*Text"
09:52:52 I logger.go:114> Log level is now 4 Error (was 2 Info)
goos: darwin
goarch: amd64
BenchmarkFortiologTextNegative     	1000000000	         2.26 ns/op	       0 B/op	       0 allocs/op
BenchmarkFortiologTextNegative-2   	1000000000	         1.16 ns/op	       0 B/op	       0 allocs/op
BenchmarkFortiologTextNegative-4   	1000000000	         0.597 ns/op	       0 B/op	       0 allocs/op
BenchmarkFortiologTextPositive     	 5252907	      1113 ns/op	     416 B/op	       9 allocs/op
BenchmarkFortiologTextPositive-2   	 9321931	       641 ns/op	     416 B/op	       9 allocs/op
BenchmarkFortiologTextPositive-4   	11926431	       554 ns/op	     416 B/op	       9 allocs/op
PASS
```