### PR TITLE
Adding phus log tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOTEST_FLAGS=-cpu=1,2,4 -benchmem -benchtime=5s
 
-TEXT_PKGS=Gokit Logrus Log15 Gologging Seelog Zerolog Fortiolog
-JSON_PKGS=Gokit Logrus Log15 Zerolog
+TEXT_PKGS=Gokit Logrus Log15 Gologging Seelog Zerolog Fortiolog Phuslog
+JSON_PKGS=Gokit Logrus Log15 Zerolog Phuslog
 
 TEXT_PKG_TARGETS=$(addprefix test-text-,$(TEXT_PKGS))
 JSON_PKG_TARGETS=$(addprefix test-json-,$(JSON_PKGS))
@@ -16,6 +16,7 @@ deps:
 	go get -u github.com/op/go-logging
 	go get -u github.com/cihub/seelog
 	go get -u github.com/go-kit/kit/log
+	go get -u github.com/phuslu/log
 	go get -u github.com/rs/zerolog
 	go get -u fortio.org/fortio
 

--- a/phuslog_test.go
+++ b/phuslog_test.go
@@ -1,0 +1,90 @@
+package bench
+
+import (
+	"testing"
+
+	"github.com/phuslu/log"
+)
+
+func BenchmarkPhuslogTextPositive(b *testing.B) {
+	stream := &blackholeStream{}
+	logger := log.Logger{
+		Writer: log.IOWriter{stream},
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info().Msg("The quick brown fox jumps over the lazy dog")
+		}
+	})
+
+	if stream.WriteCount() != uint64(b.N) {
+		b.Fatalf("Log write count")
+	}
+}
+
+func BenchmarkPhuslogTextNegative(b *testing.B) {
+	stream := &blackholeStream{}
+	logger := log.Logger{
+		Level:  log.ErrorLevel,
+		Writer: log.IOWriter{stream},
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info().Msg("The quick brown fox jumps over the lazy dog")
+		}
+	})
+
+	if stream.WriteCount() != uint64(0) {
+		b.Fatalf("Log write count")
+	}
+}
+
+func BenchmarkPhuslogJSONNegative(b *testing.B) {
+	stream := &blackholeStream{}
+	logger := log.Logger{
+		Level:  log.ErrorLevel,
+		Writer: log.IOWriter{stream},
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info().
+				Str("rate", "15").
+				Int("low", 16).
+				Float32("high", 123.2).
+				Msg("The quick brown fox jumps over the lazy dog")
+		}
+	})
+
+	if stream.WriteCount() != uint64(0) {
+		b.Fatalf("Log write count")
+	}
+}
+
+func BenchmarkPhuslogJSONPositive(b *testing.B) {
+	stream := &blackholeStream{}
+	logger := log.Logger{
+		Writer: log.IOWriter{stream},
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info().
+				Str("rate", "15").
+				Int("low", 16).
+				Float32("high", 123.2).
+				Msg("The quick brown fox jumps over the lazy dog")
+		}
+	})
+
+	if stream.WriteCount() != uint64(b.N) {
+		b.Fatalf("Log write count")
+	}
+}
+


### PR DESCRIPTION
phuslog(https://github.com/phuslu/log) is a structure logging similar with zerolog
1. simple logger & writer usage
2. optimize with time & json string format. (it always outputs time field)

Here's test result in 1 core 2 G memory VPS, roughly 2x faster than other libs in positive cases.
```
$ go test -cpu=1,2,4 -benchmem -benchtime=5s -bench "Phuslog.*"
goos: linux
goarch: amd64
BenchmarkPhuslogTextPositive     	 9379992	       581 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogTextPositive-2   	10509753	       574 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogTextPositive-4   	10325152	       586 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogTextNegative     	795419323	         7.52 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogTextNegative-2   	803406294	         7.44 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogTextNegative-4   	803390562	         7.47 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogJSONNegative     	393965690	        15.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogJSONNegative-2   	396116095	        15.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogJSONNegative-4   	393541431	        15.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogJSONPositive     	 6977595	       861 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogJSONPositive-2   	 7022749	       844 ns/op	       0 B/op	       0 allocs/op
BenchmarkPhuslogJSONPositive-4   	 6974713	       851 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	_/home/phuslu/go-loggers-bench	82.845s
```